### PR TITLE
Changes the name of the interfaces for carriers in order to give better names

### DIFF
--- a/src/OpenTracing/Carriers/HttpHeaders.php
+++ b/src/OpenTracing/Carriers/HttpHeaders.php
@@ -3,11 +3,11 @@
 namespace OpenTracing\Carriers;
 
 use ArrayIterator;
-use OpenTracing\Propagators\TextMapReader;
-use OpenTracing\Propagators\TextMapWriter;
+use OpenTracing\Propagators\Reader;
+use OpenTracing\Propagators\Writer;
 use Psr\Http\Message\RequestInterface;
 
-final class HttpHeaders implements TextMapReader, TextMapWriter
+final class HttpHeaders implements Reader, Writer
 {
     private $items = [];
 

--- a/src/OpenTracing/Carriers/TextMap.php
+++ b/src/OpenTracing/Carriers/TextMap.php
@@ -3,10 +3,10 @@
 namespace OpenTracing\Carriers;
 
 use ArrayIterator;
-use OpenTracing\Propagators\TextMapReader;
-use OpenTracing\Propagators\TextMapWriter;
+use OpenTracing\Propagators\Reader;
+use OpenTracing\Propagators\Writer;
 
-final class TextMap implements TextMapReader, TextMapWriter
+final class TextMap implements Reader, Writer
 {
     private $items = [];
 

--- a/src/OpenTracing/NoopTracer.php
+++ b/src/OpenTracing/NoopTracer.php
@@ -2,8 +2,8 @@
 
 namespace OpenTracing;
 
-use OpenTracing\Propagators\TextMapReader;
-use OpenTracing\Propagators\TextMapWriter;
+use OpenTracing\Propagators\Reader;
+use OpenTracing\Propagators\Writer;
 use TracingContext\TracingContext;
 
 final class NoopTracer implements Tracer
@@ -27,11 +27,11 @@ final class NoopTracer implements Tracer
         return NoopSpan::create();
     }
 
-    public function inject(SpanContext $spanContext, $format, TextMapWriter $carrier)
+    public function inject(SpanContext $spanContext, $format, Writer $carrier)
     {
     }
 
-    public function extract($format, TextMapReader $carrier)
+    public function extract($format, Reader $carrier)
     {
         return SpanContext::createAsDefault();
     }

--- a/src/OpenTracing/Propagator.php
+++ b/src/OpenTracing/Propagator.php
@@ -2,8 +2,8 @@
 
 namespace OpenTracing;
 
-use OpenTracing\Propagators\TextMapReader;
-use OpenTracing\Propagators\TextMapWriter;
+use OpenTracing\Propagators\Reader;
+use OpenTracing\Propagators\Writer;
 
 interface Propagator
 {
@@ -12,13 +12,13 @@ interface Propagator
 
     /**
      * @param Span $span
-     * @param TextMapWriter $carrier
+     * @param Writer $carrier
      */
-    public function inject(Span $span, TextMapWriter $carrier);
+    public function inject(Span $span, Writer $carrier);
 
     /**
-     * @param TextMapReader $carrier
+     * @param Reader $carrier
      * @return SpanContext
      */
-    public function extract(TextMapReader $carrier);
+    public function extract(Reader $carrier);
 }

--- a/src/OpenTracing/Propagators/Reader.php
+++ b/src/OpenTracing/Propagators/Reader.php
@@ -4,7 +4,7 @@ namespace OpenTracing\Propagators;
 
 use IteratorAggregate;
 
-interface TextMapReader extends IteratorAggregate
+interface Reader extends IteratorAggregate
 {
 
 }

--- a/src/OpenTracing/Propagators/Writer.php
+++ b/src/OpenTracing/Propagators/Writer.php
@@ -2,7 +2,7 @@
 
 namespace OpenTracing\Propagators;
 
-interface TextMapWriter
+interface Writer
 {
     /**
      * @param string $key

--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -2,8 +2,8 @@
 
 namespace OpenTracing;
 
-use OpenTracing\Propagators\TextMapReader;
-use OpenTracing\Propagators\TextMapWriter;
+use OpenTracing\Propagators\Reader;
+use OpenTracing\Propagators\Writer;
 
 interface Tracer
 {
@@ -32,16 +32,16 @@ interface Tracer
     /**
      * @param SpanContext $spanContext
      * @param string $format
-     * @param TextMapWriter $carrier
+     * @param Writer $carrier
      */
-    public function inject(SpanContext $spanContext, $format, TextMapWriter $carrier);
+    public function inject(SpanContext $spanContext, $format, Writer $carrier);
 
     /**
      * @param string $format
-     * @param TextMapReader $carrier
+     * @param Reader $carrier
      * @return SpanContext
      */
-    public function extract($format, TextMapReader $carrier);
+    public function extract($format, Reader $carrier);
 
     /**
      * Allow tracer to send span data to be instrumented.


### PR DESCRIPTION
As @beberlei pointed out on https://github.com/jcchavezs/opentracing-php/commit/b3fed5e84b8aa5667258778b2b3c17de5dd5b7f8#commitcomment-22511152

> Is there a reason this is a TextMapWriter/Reader since this could also be binary data, wouldn't be a simple Carrier interface or something be more "true" for naming purposes?

This PR changes the name for the reader/writer interfaces on carriers.